### PR TITLE
Replace deprecated :unprocessable_entity with :unprocessable_content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## unreleased
+
+- [BREAKING] Replace deprecated `:unprocessable_entity` with `:unprocessable_content`
+- [BREAKING] Set minimum rack version to `3.1.0`
+
 ## [0.1.2] (2023-11-12)
 
 - Don't error in case object is not encrypted

--- a/actionmailbox_amazon_ses_ingress.gemspec
+++ b/actionmailbox_amazon_ses_ingress.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/denkungsart"
 
   spec.add_dependency "rails", ">= 7.0.7.2"
+  spec.add_dependency "rack", ">= 3.1.0"
   spec.add_dependency 'aws-sdk-sns', '~> 1.65'
   spec.add_dependency 'aws-sdk-s3', '~> 1.134'
 

--- a/app/controllers/action_mailbox/ingresses/amazon_ses/subscriptions_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/amazon_ses/subscriptions_controller.rb
@@ -9,7 +9,7 @@ module ActionMailbox
             head :ok
           else
             Rails.logger.error "SNS subscription confirmation request rejected."
-            head :unprocessable_entity
+            head :unprocessable_content
           end
         end
 


### PR DESCRIPTION
References https://github.com/denkungsart/filmmakers/pull/13548

- replace deprecated `:unprocessable_entity` with `:unprocessable_content`
- set minimum rack version
- update changelog